### PR TITLE
Add ARM64 (aarch64) platform support

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,35 +24,40 @@ jobs:
       - name: Get image tags
         id: image_tags
         run: |
+          REGISTRY="${{ vars.IMAGE_REGISTRY }}/${{ vars.IMAGE_REPOSITORY }}"
+          IMAGE="${REGISTRY}/${{ vars.IMAGE_NAME }}"
+
           if [[ -n "${{ github.event.inputs.version }}" ]]; then
-            # For workflow_dispatch, use only the version provided
-            VERSION=${{ github.event.inputs.version }}
-            RELEASE=${{ github.event.inputs.version }}
-            echo "IMAGE_TAGS=${VERSION}" >> $GITHUB_OUTPUT
+            VERSION="${{ github.event.inputs.version }}"
+            TAGS="${IMAGE}:${VERSION}"
           else
-            # For tag events, use semantic versioning tags
-            # GITHUB_REF will be of the form "refs/tags/v0.1.2" or "refs/tags/v0.1.2-1"
-            # To determine VERSION, strip off the leading "refs/tags/"
-            VERSION=${GITHUB_REF#refs/tags/}
-            echo "IMAGE_TAGS=latest ${VERSION%.*} ${VERSION}" >> $GITHUB_OUTPUT
+            VERSION="${GITHUB_REF#refs/tags/}"
+            MINOR="${VERSION%.*}"
+            TAGS="${IMAGE}:latest,${IMAGE}:${MINOR},${IMAGE}:${VERSION}"
           fi
 
-      - name: Buildah Action
-        id: buildah-build
-        if: steps.image_tags.outputs.IMAGE_TAGS
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: ${{ vars.IMAGE_NAME }}
-          tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}
-          containerfiles: Containerfile
+          echo "TAGS=${TAGS}" >> "$GITHUB_OUTPUT"
 
-      - name: Push image to registry
-        id: push-to-registry
-        if: steps.image_tags.outputs.IMAGE_TAGS
-        uses: redhat-actions/push-to-registry@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to registry
+        uses: docker/login-action@v3
         with:
-          image: ${{ steps.buildah-build.outputs.image }}
-          tags: ${{ steps.buildah-build.outputs.tags }}
-          registry: ${{ vars.IMAGE_REGISTRY }}/${{ vars.IMAGE_REPOSITORY }}
+          registry: ${{ vars.IMAGE_REGISTRY }}
           username: ${{ secrets.IMAGE_REGISTRY_USERNAME }}
           password: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
+
+      - name: Build and push multi-arch image
+        if: steps.image_tags.outputs.TAGS
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.image_tags.outputs.TAGS }}
+

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,6 +51,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -36,6 +36,9 @@ jobs:
         run: |
           sed -i -e "s|^FROM .*|FROM ${{ steps.image_tags.outputs.IMAGE_TAGS }}|" ./examples/kopf-simple/Dockerfile
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         if: steps.image_tags.outputs.IMAGE_TAGS
@@ -48,6 +51,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}
           cache-from: type=gha,scope=${{ vars.IMAGE_NAME }}
@@ -58,6 +62,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./examples/kopf-simple
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.image_tags.outputs.EXAMPLE_TAGS }}
           cache-from: type=gha,scope=${{ vars.IMAGE_NAME }}

--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,8 @@ FROM registry.access.redhat.com/ubi9/python-312:latest
 
 MAINTAINER Johnathan Kupferer <jkupfere@redhat.com>
 
+ARG TARGETARCH
+
 ENV OPENSHIFT_CLIENT_VERSION=4.14.43 \
     HELM_VERSION=3.16.2
 
@@ -20,14 +22,15 @@ COPY s2i /usr/libexec/s2i
 EXPOSE 8080
 
 RUN pip3 install --upgrade -r /opt/app-root/install/requirements.txt && \
-    echo "Installing OpenShift command line client ${OPENSHIFT_CLIENT_VERSION}" && \
-    curl -L --silent --show-error https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_CLIENT_VERSION}/openshift-client-linux.tar.gz --output openshift-client.tar.gz && \
+    OC_SUFFIX=$([ "${TARGETARCH}" = "arm64" ] && echo "-arm64" || echo "") && \
+    echo "Installing OpenShift command line client ${OPENSHIFT_CLIENT_VERSION} (${TARGETARCH})" && \
+    curl -L --silent --show-error https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_CLIENT_VERSION}/openshift-client-linux${OC_SUFFIX}.tar.gz --output openshift-client.tar.gz && \
     ls -l openshift-client.tar.gz && \
     tar zxf openshift-client.tar.gz -C /usr/local/bin oc kubectl && \
     rm openshift-client.tar.gz && \
-    echo "Installing Helm command line ${HELM_VERSION}" && \
-    curl -L --silent --show-error https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz --output helm.tar.gz && \
-    tar zxf helm.tar.gz -C /usr/local/bin --strip-components=1 linux-amd64/helm && \
+    echo "Installing Helm command line ${HELM_VERSION} (${TARGETARCH})" && \
+    curl -L --silent --show-error https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz --output helm.tar.gz && \
+    tar zxf helm.tar.gz -C /usr/local/bin --strip-components=1 linux-${TARGETARCH}/helm && \
     rm helm.tar.gz && \
     chmod --recursive g+w /opt/app-root /usr/local && \
     chown --recursive 1001:0 /opt/app-root /usr/local && \

--- a/examples/openshift-template-deployer/.s2i/bin/assemble
+++ b/examples/openshift-template-deployer/.s2i/bin/assemble
@@ -3,7 +3,8 @@
 . /usr/libexec/s2i/assemble
 
 OCP_VERSION="${OCP_VERSION:-4.3.1}"
+OC_ARCH_SUFFIX=$(uname -m | grep -q aarch64 && echo "-arm64" || echo "")
 
 mkdir -p /opt/app-root/bin
-curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_VERSION}/openshift-client-linux-${OCP_VERSION}.tar.gz \
+curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_VERSION}/openshift-client-linux${OC_ARCH_SUFFIX}-${OCP_VERSION}.tar.gz \
   | tar zxvf - -C /opt/app-root/bin kubectl oc


### PR DESCRIPTION
- Update Containerfile to dynamically select `oc` and Helm binaries based on target architecture via BuildKit `TARGETARCH`
- Migrate publish workflow from Buildah to Docker Buildx with QEMU for multi-arch builds (linux/amd64, linux/arm64)
- Add QEMU and multi-platform build support to pull-request workflow
- Update example s2i assemble script for architecture-aware oc client download
